### PR TITLE
Use mb_substr for multibyte support

### DIFF
--- a/src/FixedWidth.php
+++ b/src/FixedWidth.php
@@ -35,7 +35,7 @@ class FixedWidth
         $line = rtrim($line);
 
         $field = $this->fields[$name];
-        $value = substr(
+        $value = mb_substr(
             $line,
             $field['start'] - $this->base,
             $field['length']

--- a/tests/FixedWidthTest.php
+++ b/tests/FixedWidthTest.php
@@ -239,6 +239,25 @@ class FixedWidthTest extends \PHPUnit_Framework_TestCase
             'a' => 'xxx',
             'b' => 4,
         ], $obj->readLine($line));
+
+        $config = [
+            'a' => [
+                'type'  => 'string',
+                'start' => 1,
+                'end'   => 5,
+            ],
+            'b' => [
+                'type'  => 'integer',
+                'start' => 6,
+                'end'   => 10,
+            ],
+        ];
+        $obj  = new FixedWidth($config);
+        $line = 'æøå  00004';
+        $this->assertSame([
+            'a' => 'æøå',
+            'b' => 4,
+        ], $obj->readLine($line));
     }
 
     public function testStringToText()


### PR DESCRIPTION
Hello!

Thanks for this library.

Just noticed that I can not use it with strings that contain multibyte characters. So here is a PR using mb_substr instead of substr, fixing it. Also contains a test that fails without the fix.